### PR TITLE
Move brp-python-bytecompile from rpm, so we can easily adapt it

### DIFF
--- a/brp-python-bytecompile
+++ b/brp-python-bytecompile
@@ -1,0 +1,112 @@
+#!/bin/bash
+errors_terminate=$2
+extra=$3
+
+# If using normal root, avoid changing anything.
+if [ -z "$RPM_BUILD_ROOT" -o "$RPM_BUILD_ROOT" = "/" ]; then
+	exit 0
+fi
+
+# Figure out how deep we need to descend.  We could pick an insanely high
+# number and hope it's enough, but somewhere, somebody's sure to run into it.
+depth=`(find "$RPM_BUILD_ROOT" -type f -name "*.py" -print0 ; echo /) | \
+       xargs -0 -n 1 dirname | sed 's,[^/],,g' | sort -u | tail -n 1 | wc -c`
+if [ -z "$depth" -o "$depth" -le "1" ]; then
+	exit 0
+fi
+
+function python_bytecompile()
+{
+    local options=$1
+    local python_binary=$2
+    local exclude=$3
+    local python_libdir=$4
+    local depth=$5
+    local real_libdir=$6
+
+cat << EOF | $python_binary $options
+import compileall, sys, os, re
+
+python_libdir = "$python_libdir"
+depth = $depth
+real_libdir = "$real_libdir"
+build_root = "$RPM_BUILD_ROOT"
+exclude = r"$exclude"
+
+class Filter:
+    def search(self, path):
+        ret = not os.path.realpath(path).startswith(build_root)
+        if exclude:
+            ret = ret or re.search(exclude, path)
+        return ret
+
+sys.exit(not compileall.compile_dir(python_libdir, depth, real_libdir, force=1, rx=Filter(), quiet=1))
+EOF
+}
+
+# .pyc/.pyo files embed a "magic" value, identifying the ABI version of Python
+# bytecode that they are for.
+#
+# The files below RPM_BUILD_ROOT could be targeting multiple versions of
+# python (e.g. a single build that emits several subpackages e.g. a
+# python26-foo subpackage, a python31-foo subpackage etc)
+#
+# Support this by assuming that below each /usr/lib/python$VERSION/, all
+# .pyc/.pyo files are to be compiled for /usr/bin/python$VERSION.
+# 
+# For example, below /usr/lib/python2.6/, we're targeting /usr/bin/python2.6
+# and below /usr/lib/python3.1/, we're targeting /usr/bin/python3.1
+
+shopt -s nullglob
+for python_libdir in `find "$RPM_BUILD_ROOT" -type d|grep -E "/usr/lib(64)?/python[0-9]\.[0-9]$"`;
+do
+	python_binary=/usr/bin/$(basename $python_libdir)
+	real_libdir=${python_libdir/$RPM_BUILD_ROOT/}
+	echo "Bytecompiling .py files below $python_libdir using $python_binary"
+
+	# Generate normal (.pyc) byte-compiled files.
+	python_bytecompile "" "$python_binary" "" "$python_libdir" "$depth" "$real_libdir"
+	if [ $? -ne 0 -a 0$errors_terminate -ne 0 ]; then
+		# One or more of the files had a syntax error
+		exit 1
+	fi
+
+	# Generate optimized (.pyo) byte-compiled files.
+	python_bytecompile "-O" "$python_binary" "" "$python_libdir" "$depth" "$real_libdir"
+	if [ $? -ne 0 -a 0$errors_terminate -ne 0 ]; then
+		# One or more of the files had a syntax error
+		exit 1
+	fi
+done
+
+
+# Handle other locations in the filesystem using the default python implementation
+# if extra is set to 0, don't do this
+if [ 0$extra -eq 0 ]; then
+	exit 0
+fi
+
+# If we don't have a default python interpreter, we cannot proceed
+default_python=${1:-/usr/bin/python}
+if [ ! -x "$default_python" ]; then
+	exit 0
+fi
+
+# Figure out if there are files to be bytecompiled with the default_python at all
+# this prevents unnecessary default_python invocation
+find "$RPM_BUILD_ROOT" -type f -name "*.py" | grep -Ev "/bin/|/sbin/|/usr/lib(64)?/python[0-9]\.[0-9]|/usr/share/doc" || exit 0
+
+# Generate normal (.pyc) byte-compiled files.
+python_bytecompile "" $default_python "/bin/|/sbin/|/usr/lib(64)?/python[0-9]\.[0-9]|/usr/share/doc" "$RPM_BUILD_ROOT" "$depth" "/"
+if [ $? -ne 0 -a 0$errors_terminate -ne 0 ]; then
+	# One or more of the files had a syntax error
+	exit 1
+fi
+
+# Generate optimized (.pyo) byte-compiled files.
+python_bytecompile "-O" $default_python "/bin/|/sbin/|/usr/lib(64)?/python[0-9]\.[0-9]|/usr/share/doc" "$RPM_BUILD_ROOT" "$depth" "/"
+if [ $? -ne 0 -a 0$errors_terminate -ne 0 ]; then
+	# One or more of the files had a syntax error
+	exit 1
+fi
+exit 0

--- a/macros
+++ b/macros
@@ -146,7 +146,7 @@ print(result)
 %__brp_strip /usr/lib/rpm/brp-strip %{__strip}
 %__brp_strip_comment_note /usr/lib/rpm/brp-strip-comment-note %{__strip} %{__objdump}
 %__brp_strip_static_archive /usr/lib/rpm/brp-strip-static-archive %{__strip}
-%__brp_python_bytecompile /usr/lib/rpm/brp-python-bytecompile "%{__python}" "%{?_python_bytecompile_errors_terminate_build}" "%{?_python_bytecompile_extra}"
+%__brp_python_bytecompile /usr/lib/rpm/redhat/brp-python-bytecompile "%{__python}" "%{?_python_bytecompile_errors_terminate_build}" "%{?_python_bytecompile_extra}"
 %__brp_python_hardlink /usr/lib/rpm/brp-python-hardlink
 # __brp_mangle_shebangs_exclude - shebangs to exclude
 # __brp_mangle_shebangs_exclude_file - file from which to get shebangs to exclude

--- a/redhat-rpm-config.spec
+++ b/redhat-rpm-config.spec
@@ -6,10 +6,10 @@
 
 Summary: Red Hat specific rpm configuration files
 Name: redhat-rpm-config
-Version: 133
-Release: 2%{?dist}
-# No version specified.
-License: GPL+
+Version: 134
+Release: 1%{?dist}
+# Originally no version specified, but stuff from rpm is version 2+
+License: GPLv2+
 URL: https://src.fedoraproject.org/rpms/redhat-rpm-config
 
 # Core rpm settings
@@ -47,6 +47,10 @@ Source155: macros.fedora-misc
 # added a python -> python2 conversion for fedora with warning
 # and an echo when the mangling happens
 Source201: brp-mangle-shebangs
+
+# this comes from rpm itself
+# however, now we can do Fedora changes within
+Source202: brp-python-bytecompile
 
 # Dependency generator scripts (deprecated)
 Source300: find-provides
@@ -95,7 +99,8 @@ Requires: nim-srpm-macros
 Requires: ocaml-srpm-macros
 Requires: openblas-srpm-macros
 Requires: perl-srpm-macros
-Requires: python-srpm-macros
+# TODO check version when putting this into fedora!
+Requires: python-srpm-macros >= 43
 Requires: rust-srpm-macros
 Requires: qt5-srpm-macros
 
@@ -202,6 +207,9 @@ install -p -m 644 -t %{buildroot}%{_rpmluadir}/fedora/srpm forge.lua
 %{_rpmconfigdir}/macros.d/macros.kmp
 
 %changelog
+* Mon Jul 01 2019 Miro Hrončok <mhroncok@redhat.com> - 134-1
+- Move brp-python-bytecompile from rpm, so we can easily adapt it
+
 * Thu Jun 27 2019 Vít Ondruch <vondruch@redhat.com> - 133-2
 - Enable RPM to set SOURCE_DATE_EPOCH environment variable.
 


### PR DESCRIPTION
@frenzymadness this is the necessary infrastrucutral change needed to adapt brp-python-bytecompile. Together with https://github.com/hroncok/python-rpm-macros/pull/1 you can assume `compileall2` is present (but not in `sys.path`).

Now the brp-python-bytecompile script needs to be adapted to work with both Python 2 and `compileall2`. I'm not sure how to do it without making it extraordinary messy.